### PR TITLE
Fixes for link color and a bonus gradient

### DIFF
--- a/dist/synthwave-hass-extras.js
+++ b/dist/synthwave-hass-extras.js
@@ -1,3 +1,8 @@
+const primaryColor = '#f92aad';
+const synthwaveGradient = 'linear-gradient(to right, #fc28a8, #03edf9)';
+
+let hacsInterval = null;
+
 // Method to pierce all shadowroots
 function queryShadow(root2 = document, filter = el => true, elements = []) {
   root2.querySelectorAll('*').forEach(element => {
@@ -35,15 +40,121 @@ setTimeout(function () {
           //       const icon = button_card.querySelector('#icon')
           //       icon.style.filter = 'drop-shadow( 0 0 8px #f39f0575)'
 
-          // Anchors
-          queryShadow(document, el => el.tagName === 'A')
-            .forEach(a => (a.style.color = '#f92aad'))
-          // Label classes eg. https://www.home-assistant.io/lovelace/entities/#label
-          queryShadow(document, el => el.className === 'label')
-            .forEach(a => (a.style.color = '#ffffff'))
-
+          applyStyles();
   }
   catch (e) {
     console.log(e)
   }
-}, 200)
+}, 200);
+
+// Poll for changes to window.location, so that we can apply styles to new elements when the page changes
+let lastWindowLocation = window.location.href;
+setInterval(function() {
+  // If the url has changes, apply styles
+  if(window.location.href !== lastWindowLocation) {
+    // Stop checking for changes to the hacs iframe location.href
+    clearInterval(hacsInterval);
+
+    // Try and wait for the new DOM elements to render
+    setTimeout(function() {
+      detectHacs();
+      applyStyles();
+    }, 100);
+
+    // Update the window location so that we can detect the next change
+    lastWindowLocation = window.location.href
+  }
+}, 250);
+
+// Apply custom styles
+function applyStyles() {
+  // Anchors
+  queryShadow(document, el => el.tagName === 'A')
+    .forEach(el => (el.style.color = primaryColor));
+  
+  // Label classes eg. https://www.home-assistant.io/lovelace/entities/#label
+  queryShadow(document, el => el.className === 'label')
+    .forEach(el => (el.style.color = '#ffffff'));
+
+  // Navigation Menu Icon
+  queryShadow(document, el => el.className === 'menu')
+    .forEach(el => {
+      el.style.background = synthwaveGradient;
+      el.style.backgroundSize = '100% 3px';
+      el.style.backgroundRepeat = 'no-repeat';
+      el.style.backgroundPositionY = '100%';
+      el.style.marginBottom = '5px';
+    });
+}
+
+function detectHacs() {
+  const rootEl = document.querySelector('home-assistant');
+  if(rootEl && rootEl.shadowRoot) {
+    const homeAssistantMainEl = rootEl.shadowRoot.querySelector('home-assistant-main');
+
+    if(homeAssistantMainEl && homeAssistantMainEl.shadowRoot) {
+      const appDrawerLayoutEl = homeAssistantMainEl.shadowRoot.querySelector('app-drawer-layout');
+
+      if(appDrawerLayoutEl) {
+        const haPanelIframeEl = appDrawerLayoutEl.querySelector('ha-panel-iframe');
+
+        if(haPanelIframeEl && haPanelIframeEl.shadowRoot) {
+          const hacsIframe = haPanelIframeEl.shadowRoot.querySelector('iframe');
+
+          if(hacsIframe) {
+            let lastHacsSrc = hacsIframe.contentWindow.location.href;
+
+            applyHacsStyles(hacsIframe);
+
+            // Poll for changes to the hacs iframe src
+            hacsInterval = setInterval(function() {
+              // If the url has changed, apply styles
+              if(hacsIframe.contentWindow.location.href !== lastHacsSrc) {
+                applyHacsStyles(hacsIframe);
+
+                // Update the window location so that we can detect the next change
+                lastHacsSrc = hacsIframe.contentWindow.location.href;
+              }
+            }, 250);
+          }
+        }
+      }
+    }
+  }
+}
+
+function applyHacsStyles(hacsIframe) {
+  let styles = `
+    a.actionlink {
+      color: ${primaryColor} !important;
+    }
+    
+    a.hacsbutton {
+      background-color: ${primaryColor} !important;
+    }
+    
+    .pending-upgrade {
+      color: ${primaryColor} !important;
+    }
+  `;
+
+  let styleEl = document.createElement("style"); 
+  styleEl.type = "text/css";  
+  styleEl.innerHTML = styles;
+
+  function waitForIframeAndApply(hacsIframe) {
+    // Get a handle to the iframe element
+    var iframeDoc = hacsIframe.contentDocument || hacsIframe.contentWindow.document;
+
+    // Check if loading is complete
+    if (iframeDoc.readyState == 'complete') {
+      hacsIframe.contentDocument.head.appendChild(styleEl); 
+      return;
+    } 
+
+    // If we are here, it is not loaded. Set things up so we check   the status again in 100 milliseconds
+    window.setTimeout(checkIframeLoaded, 100);
+  };
+
+  waitForIframeAndApply(hacsIframe);
+}


### PR DESCRIPTION
• Fix color of links in hass (states, events, etc...)
• Fix colour of links and some buttons in Hacs
• Add Synthwave '84 gradient at the top of the nav bar

Attempted fixes as per the issues reported in https://github.com/bbbenji/synthwave-hass/issues/11

OK, so it appeared the link coloring was only taking effect when on a lovelace enabled page, so I added a little something to check if the window.location.href had changed and then re-applied the styles.

While I was there, I knocked together something to try and address the problem with HACS links not being visible against the background. It's not really pretty, since HACS is hidden away in the murky depths of multiple shadow roots, and an iframe, but since we're using a local iframe here we don't need to worry about XSS blocking us from making modifications.

I did my best to not use any dirty practises, but I had to make exceptions where they were needed - these issues had been present for a little bit now, and I wanted to fix them the best I could to keep using this theme (without going on a marathon learning spree into the depths of hass).

I also added a little gradient to the top of the nav bar, as seen on the inpiration for this theme, the VS Code Synthwave '84 theme, as can be seen in the screens below.

![synthwave-gradient-open](https://user-images.githubusercontent.com/1283019/69489636-33203c80-0e73-11ea-828a-4d6a2f3cebb8.png)
![synthwave-gradient-collapsed](https://user-images.githubusercontent.com/1283019/69489637-33203c80-0e73-11ea-8946-7fc0f2d74939.png)

I did my best to keep testing while making these changes, but I really only had a few hours free tonight, so YMMV.