### PR TITLE
Fix synthwave gradient not showing in lovelace sidebar

### DIFF
--- a/dist/synthwave-hass-extras.js
+++ b/dist/synthwave-hass-extras.js
@@ -29,7 +29,7 @@ setTimeout(function () {
           // Sidebar
           const sidebar = main.querySelector('ha-sidebar').shadowRoot
             // Title
-            const title = sidebar.querySelector('div.menu > span')
+            const title = sidebar.querySelector('div.menu')
             title.style.textShadow = '0 0 2px #393a33, 0 0 35px #ffffff44, 0 0 8px #f39f0575, 0 0 2px #f39f0575'
             title.style.color = primaryColor
           // const hui_root = lovelace.querySelector('hui-root').shadowRoot


### PR DESCRIPTION
Recently, during the month of WTH, the Home Assistant team did some work on the sidebar, to allow the re-ordering and hiding of menu items.

Looks like they changed the markup surrounding the title, and this knocked out the query selector that grabbed the title span, thus we lost the synthwave gradient that was there.

This is a quick fix to target the parent element, and apply the gradient to that instead.

It's not extensively tested, I threw this together in a couple of mins, but it seemed to be working fine over here.